### PR TITLE
Make it possible that the auth token url can be a relative path.

### DIFF
--- a/src/pinger.py
+++ b/src/pinger.py
@@ -49,7 +49,7 @@ def worker(url):
             if settings.get('token_auth'):
                 auth_token = ''
                 try:
-                    auth_token = request_token()
+                    auth_token = request_token(url)
                 except Exception as e:
                     log.error(e)
                 header = settings['token_auth'].get('header')


### PR DESCRIPTION
 If so, the pinger uses the target url's domain plus that path to get an auth token.

This is useful if there is not one auth server, but each pinged domain provides auth tokens themselves. User credentials will still need to be the same across domains, though.